### PR TITLE
feat: module to withdraw from uniswap v2

### DIFF
--- a/contracts/BaseModule.sol
+++ b/contracts/BaseModule.sol
@@ -38,9 +38,18 @@ contract BaseModule {
     /// @notice Allows executing specific calldata into an address thru a gnosis-safe, which have enable this contract as module.
     /// @param to Contract address where we will execute the calldata.
     /// @param data Calldata to be executed within the boundaries of the `allowedFunctions`.
-    function _checkTransactionAndExecute(ISafe safe, address to, bytes memory data) internal {
+    function _checkTransactionAndExecute(
+        ISafe safe,
+        address to,
+        bytes memory data
+    ) internal {
         if (data.length >= 4) {
-            bool success = safe.execTransactionFromModule(to, 0, data, ISafe.Operation.Call);
+            bool success = safe.execTransactionFromModule(
+                to,
+                0,
+                data,
+                ISafe.Operation.Call
+            );
             if (!success) revert ExecutionFailure(to, data, block.timestamp);
         }
     }
@@ -49,13 +58,19 @@ contract BaseModule {
     /// @param to Contract address where we will execute the calldata.
     /// @param data Calldata to be executed within the boundaries of the `allowedFunctions`.
     /// @return bytes data containing the return data from the method in `to` with the payload `data`
-    function _checkTransactionAndExecuteReturningData(ISafe safe, address to, bytes memory data)
-        internal
-        returns (bytes memory)
-    {
+    function _checkTransactionAndExecuteReturningData(
+        ISafe safe,
+        address to,
+        bytes memory data
+    ) internal returns (bytes memory) {
         if (data.length >= 4) {
-            (bool success, bytes memory returnData) =
-                safe.execTransactionFromModuleReturnData(to, 0, data, ISafe.Operation.Call);
+            (bool success, bytes memory returnData) = safe
+                .execTransactionFromModuleReturnData(
+                    to,
+                    0,
+                    data,
+                    ISafe.Operation.Call
+                );
             if (!success) revert ExecutionFailure(to, data, block.timestamp);
             return returnData;
         }

--- a/contracts/ModuleFactory.sol
+++ b/contracts/ModuleFactory.sol
@@ -21,7 +21,12 @@ contract ModuleFactory {
     // EVENTS
     ////////////////////////////////////////////////////////////////////////////
 
-    event ModuleDeployed(address module, ModuleType moduleType, address deployer, uint256 timestamp);
+    event ModuleDeployed(
+        address module,
+        ModuleType moduleType,
+        address deployer,
+        uint256 timestamp
+    );
 
     ////////////////////////////////////////////////////////////////////////////
     // CONSTANTS
@@ -39,10 +44,20 @@ contract ModuleFactory {
     function createModuleAndEnable(ISafe safe, ModuleType modType) external {
         if (modType == ModuleType.REVOKE_MODULE) {
             RevokeModule module = new RevokeModule(safe);
-            emit ModuleDeployed(address(module), ModuleType.REVOKE_MODULE, msg.sender, block.timestamp);
+            emit ModuleDeployed(
+                address(module),
+                ModuleType.REVOKE_MODULE,
+                msg.sender,
+                block.timestamp
+            );
         } else if (modType == ModuleType.AAVE_WITHDRAW) {
             AaveWithdrawModule module = new AaveWithdrawModule(safe);
-            emit ModuleDeployed(address(module), ModuleType.AAVE_WITHDRAW, msg.sender, block.timestamp);
+            emit ModuleDeployed(
+                address(module),
+                ModuleType.AAVE_WITHDRAW,
+                msg.sender,
+                block.timestamp
+            );
         } else {
             revert NoSupportedModuleType(modType, msg.sender);
         }

--- a/contracts/modules/AaveWithdrawModule.sol
+++ b/contracts/modules/AaveWithdrawModule.sol
@@ -18,19 +18,29 @@ contract AaveWithdrawModule is BaseModule {
     // CONSTANTS
     ////////////////////////////////////////////////////////////////////////////
 
-    IAaveV3Pool AAVE_POOL = IAaveV3Pool(0x7b5C526B7F8dfdff278b4a3e045083FBA4028790);
+    IAaveV3Pool AAVE_POOL =
+        IAaveV3Pool(0x7b5C526B7F8dfdff278b4a3e045083FBA4028790);
 
     ////////////////////////////////////////////////////////////////////////////
     // ERRORS
     ////////////////////////////////////////////////////////////////////////////
 
-    error CollateralNotSupported(address collateral, address signer, uint256 timestamp);
+    error CollateralNotSupported(
+        address collateral,
+        address signer,
+        uint256 timestamp
+    );
 
     ////////////////////////////////////////////////////////////////////////////
     // EVENTS
     ////////////////////////////////////////////////////////////////////////////
 
-    event EmergencyWithdraw(address asset, uint256 amount, address signer, uint256 timestamp);
+    event EmergencyWithdraw(
+        address asset,
+        uint256 amount,
+        address signer,
+        uint256 timestamp
+    );
 
     constructor(ISafe _safe) {
         safe = ISafe(_safe);
@@ -39,19 +49,34 @@ contract AaveWithdrawModule is BaseModule {
     function aaveV3Withdraw(address collateral) external isSigner(safe) {
         if (!safe.isModuleEnabled(address(this))) revert ModuleMisconfigured();
 
-        DataTypes.ReserveData memory reserveData = AAVE_POOL.getReserveData(collateral);
+        DataTypes.ReserveData memory reserveData = AAVE_POOL.getReserveData(
+            collateral
+        );
 
         address aTokenAddress = reserveData.aTokenAddress;
-        if (aTokenAddress == address(0)) revert CollateralNotSupported(collateral, msg.sender, block.timestamp);
+        if (aTokenAddress == address(0))
+            revert CollateralNotSupported(
+                collateral,
+                msg.sender,
+                block.timestamp
+            );
 
         uint256 collateralBal = IAToken(aTokenAddress).balanceOf(address(safe));
         if (collateralBal > 0) {
             _checkTransactionAndExecute(
                 safe,
                 address(AAVE_POOL),
-                abi.encodeCall(IAaveV3Pool.withdraw, (collateral, type(uint256).max, address(safe)))
+                abi.encodeCall(
+                    IAaveV3Pool.withdraw,
+                    (collateral, type(uint256).max, address(safe))
+                )
             );
-            emit EmergencyWithdraw(collateral, collateralBal, msg.sender, block.timestamp);
+            emit EmergencyWithdraw(
+                collateral,
+                collateralBal,
+                msg.sender,
+                block.timestamp
+            );
         }
     }
 }

--- a/contracts/modules/RevokeModule.sol
+++ b/contracts/modules/RevokeModule.sol
@@ -16,7 +16,13 @@ contract RevokeModule is BaseModule {
     // EVENTS
     ////////////////////////////////////////////////////////////////////////////
 
-    event Revoked(address safe, address token, address spender, address signer, uint256 timestamp);
+    event Revoked(
+        address safe,
+        address token,
+        address spender,
+        address signer,
+        uint256 timestamp
+    );
 
     constructor(ISafe _safe) {
         safe = ISafe(_safe);
@@ -25,10 +31,23 @@ contract RevokeModule is BaseModule {
     function revoke(address token, address spender) external isSigner(safe) {
         if (!safe.isModuleEnabled(address(this))) revert ModuleMisconfigured();
 
-        uint256 allowanceAmount = IERC20(token).allowance(address(safe), spender);
+        uint256 allowanceAmount = IERC20(token).allowance(
+            address(safe),
+            spender
+        );
         if (allowanceAmount > 0) {
-            _checkTransactionAndExecute(safe, token, abi.encodeCall(IERC20.approve, (spender, 0)));
-            emit Revoked(address(safe), token, spender, msg.sender, block.timestamp);
+            _checkTransactionAndExecute(
+                safe,
+                token,
+                abi.encodeCall(IERC20.approve, (spender, 0))
+            );
+            emit Revoked(
+                address(safe),
+                token,
+                spender,
+                msg.sender,
+                block.timestamp
+            );
         }
     }
 }

--- a/contracts/modules/UniswapWithdrawModule.sol
+++ b/contracts/modules/UniswapWithdrawModule.sol
@@ -31,6 +31,7 @@ contract UniswapWithdrawModule is BaseModule {
     ////////////////////////////////////////////////////////////////////////////
 
     error LpNotSupported(address lp, address signer, uint256 timestamp);
+    error ZeroBalance(address token, address signer, uint256 timestamp);
 
     ////////////////////////////////////////////////////////////////////////////
     // EVENTS
@@ -53,10 +54,19 @@ contract UniswapWithdrawModule is BaseModule {
         address token0 = ULP.token0();
         address token1 = ULP.token1();
 
-        uint256 wethBefore = WETH.balanceOf(address(safe));
+        if ((token0 == address(0)) || (token1 == address(0))) {
+            revert LpNotSupported(lp, msg.sender, block.timestamp);
+        }
+
+        // TODO: see L99
+        // uint256 wethBefore = WETH.balanceOf(address(safe));
 
         // assume withdrawal of total balance
         uint256 ulpAmount = ULP.balanceOf(address(safe));
+
+        if (ulpAmount == 0) {
+            revert ZeroBalance(lp, msg.sender, block.timestamp);
+        }
 
         (uint256 reserves0, uint256 reserves1, ) = ULP.getReserves();
         uint256 expectedAsset0 = (reserves0 * ulpAmount) / ULP.totalSupply();
@@ -96,6 +106,4 @@ contract UniswapWithdrawModule is BaseModule {
         //     );
         // }
     }
-
-    fallback() external payable {}
 }

--- a/contracts/modules/UniswapWithdrawModule.sol
+++ b/contracts/modules/UniswapWithdrawModule.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "interfaces/ISafe.sol";
+import {IUniswapV2Router02} from "interfaces/uniswap_v2/IUniswapV2Router02.sol";
+import {IUniswapV2Pair} from "interfaces/uniswap_v2/IUniswapV2Pair.sol";
+import {IWETH9} from "interfaces/IWETH9.sol";
+import {BaseModule} from "../BaseModule.sol";
+
+contract UniswapWithdrawModule is BaseModule {
+    ////////////////////////////////////////////////////////////////////////////
+    // INMUTABLE VARIABLES
+    ////////////////////////////////////////////////////////////////////////////
+    ISafe public immutable safe;
+
+    ////////////////////////////////////////////////////////////////////////////
+    // CONSTANTS
+    ////////////////////////////////////////////////////////////////////////////
+
+    IUniswapV2Router02 internal constant UNIV2_ROUTER2 =
+        IUniswapV2Router02(payable(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D));
+    IWETH9 internal constant WETH =
+        IWETH9(0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6);
+
+    uint256 MAX_BPS = 10_000;
+    uint256 SLIPPAGE_BPS = 50;
+
+    ////////////////////////////////////////////////////////////////////////////
+    // ERRORS
+    ////////////////////////////////////////////////////////////////////////////
+
+    error LpNotSupported(address lp, address signer, uint256 timestamp);
+
+    ////////////////////////////////////////////////////////////////////////////
+    // EVENTS
+    ////////////////////////////////////////////////////////////////////////////
+
+    event EmergencyWithdraw(
+        address asset,
+        uint256 amount,
+        address signer,
+        uint256 timestamp
+    );
+
+    constructor(ISafe _safe) {
+        safe = ISafe(_safe);
+    }
+
+    function uniswapV2Withdraw(address lp) external isSigner(safe) {
+        // https://docs.uniswap.org/contracts/v2/reference/smart-contracts/router-02#removeliquidity
+        IUniswapV2Pair ULP = IUniswapV2Pair(lp);
+        address token0 = ULP.token0();
+        address token1 = ULP.token1();
+
+        uint256 wethBefore = WETH.balanceOf(address(safe));
+
+        // assume withdrawal of total balance
+        uint256 ulpAmount = ULP.balanceOf(address(safe));
+
+        (uint256 reserves0, uint256 reserves1, ) = ULP.getReserves();
+        uint256 expectedAsset0 = (reserves0 * ulpAmount) / ULP.totalSupply();
+        uint256 expectedAsset1 = (reserves1 * ulpAmount) / ULP.totalSupply();
+
+        _checkTransactionAndExecute(
+            safe,
+            address(ULP),
+            abi.encodeCall(
+                IUniswapV2Pair.approve,
+                (address(UNIV2_ROUTER2), ulpAmount)
+            )
+        );
+        _checkTransactionAndExecute(
+            safe,
+            address(UNIV2_ROUTER2),
+            abi.encodeCall(
+                IUniswapV2Router02.removeLiquidity,
+                (
+                    token0,
+                    token1,
+                    ulpAmount,
+                    (expectedAsset0 * (MAX_BPS - SLIPPAGE_BPS)) / MAX_BPS,
+                    (expectedAsset1 * (MAX_BPS - SLIPPAGE_BPS)) / MAX_BPS,
+                    address(safe),
+                    block.timestamp
+                )
+            )
+        );
+        // TODO: gnosis safe has bugged fallback
+        // uint256 wethAfter = WETH.balanceOf(address(safe));
+        // if (wethAfter > wethBefore) {
+        //     _checkTransactionAndExecute(
+        //         safe,
+        //         address(WETH),
+        //         abi.encodeCall(IWETH9.withdraw, wethAfter - wethBefore)
+        //     );
+        // }
+    }
+
+    fallback() external payable {}
+}

--- a/contracts/testContracts/TokenErc20.sol
+++ b/contracts/testContracts/TokenErc20.sol
@@ -4,7 +4,10 @@ pragma solidity ^0.8.4;
 import "@openzeppelin/contracts/mocks/ERC20Mock.sol";
 
 contract TokenErc20 is ERC20Mock {
-    constructor(string memory name, string memory symbol, address initialAccount, uint256 initialBalance)
-        ERC20Mock(name, symbol, initialAccount, initialBalance)
-    {}
+    constructor(
+        string memory name,
+        string memory symbol,
+        address initialAccount,
+        uint256 initialBalance
+    ) ERC20Mock(name, symbol, initialAccount, initialBalance) {}
 }

--- a/interfaces/ISafe.sol
+++ b/interfaces/ISafe.sol
@@ -3,7 +3,7 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 interface ISafe {
-     enum Operation {
+    enum Operation {
         Call,
         DelegateCall
     }

--- a/interfaces/IWETH9.sol
+++ b/interfaces/IWETH9.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.4.19;
+
+interface IWETH9 {
+    function name() external view returns (string memory);
+
+    function approve(address guy, uint256 wad) external returns (bool);
+
+    function totalSupply() external view returns (uint256);
+
+    function transferFrom(
+        address src,
+        address dst,
+        uint256 wad
+    ) external returns (bool);
+
+    function withdraw(uint256 wad) external;
+
+    function decimals() external view returns (uint8);
+
+    function balanceOf(address) external view returns (uint256);
+
+    function symbol() external view returns (string memory);
+
+    function transfer(address dst, uint256 wad) external returns (bool);
+
+    function deposit() external payable;
+
+    function allowance(address, address) external view returns (uint256);
+
+    // function() external payable;
+    event Approval(address indexed src, address indexed guy, uint256 wad);
+    event Transfer(address indexed src, address indexed dst, uint256 wad);
+    event Deposit(address indexed dst, uint256 wad);
+    event Withdrawal(address indexed src, uint256 wad);
+}

--- a/interfaces/uniswap_v2/IUniswapV2Pair.sol
+++ b/interfaces/uniswap_v2/IUniswapV2Pair.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.5.16;
+
+interface IUniswapV2Pair {
+    event Approval(
+        address indexed owner,
+        address indexed spender,
+        uint256 value
+    );
+    event Burn(
+        address indexed sender,
+        uint256 amount0,
+        uint256 amount1,
+        address indexed to
+    );
+    event Mint(address indexed sender, uint256 amount0, uint256 amount1);
+    event Swap(
+        address indexed sender,
+        uint256 amount0In,
+        uint256 amount1In,
+        uint256 amount0Out,
+        uint256 amount1Out,
+        address indexed to
+    );
+    event Sync(uint112 reserve0, uint112 reserve1);
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+
+    function MINIMUM_LIQUIDITY() external view returns (uint256);
+
+    function PERMIT_TYPEHASH() external view returns (bytes32);
+
+    function allowance(address, address) external view returns (uint256);
+
+    function approve(address spender, uint256 value) external returns (bool);
+
+    function balanceOf(address) external view returns (uint256);
+
+    function burn(
+        address to
+    ) external returns (uint256 amount0, uint256 amount1);
+
+    function decimals() external view returns (uint8);
+
+    function factory() external view returns (address);
+
+    function getReserves()
+        external
+        view
+        returns (
+            uint112 _reserve0,
+            uint112 _reserve1,
+            uint32 _blockTimestampLast
+        );
+
+    function initialize(address _token0, address _token1) external;
+
+    function kLast() external view returns (uint256);
+
+    function mint(address to) external returns (uint256 liquidity);
+
+    function name() external view returns (string memory);
+
+    function nonces(address) external view returns (uint256);
+
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    function price0CumulativeLast() external view returns (uint256);
+
+    function price1CumulativeLast() external view returns (uint256);
+
+    function skim(address to) external;
+
+    function swap(
+        uint256 amount0Out,
+        uint256 amount1Out,
+        address to,
+        bytes calldata data
+    ) external;
+
+    function symbol() external view returns (string memory);
+
+    function sync() external;
+
+    function token0() external view returns (address);
+
+    function token1() external view returns (address);
+
+    function totalSupply() external view returns (uint256);
+
+    function transfer(address to, uint256 value) external returns (bool);
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 value
+    ) external returns (bool);
+}

--- a/interfaces/uniswap_v2/IUniswapV2Router02.sol
+++ b/interfaces/uniswap_v2/IUniswapV2Router02.sol
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.6.6;
+
+interface IUniswapV2Router02 {
+    function WETH() external view returns (address);
+
+    function addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 amountADesired,
+        uint256 amountBDesired,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    ) external returns (uint256 amountA, uint256 amountB, uint256 liquidity);
+
+    function addLiquidityETH(
+        address token,
+        uint256 amountTokenDesired,
+        uint256 amountTokenMin,
+        uint256 amountETHMin,
+        address to,
+        uint256 deadline
+    )
+        external
+        payable
+        returns (uint256 amountToken, uint256 amountETH, uint256 liquidity);
+
+    function factory() external view returns (address);
+
+    function getAmountIn(
+        uint256 amountOut,
+        uint256 reserveIn,
+        uint256 reserveOut
+    ) external pure returns (uint256 amountIn);
+
+    function getAmountOut(
+        uint256 amountIn,
+        uint256 reserveIn,
+        uint256 reserveOut
+    ) external pure returns (uint256 amountOut);
+
+    function getAmountsIn(
+        uint256 amountOut,
+        address[] calldata path
+    ) external view returns (uint256[] memory amounts);
+
+    function getAmountsOut(
+        uint256 amountIn,
+        address[] calldata path
+    ) external view returns (uint256[] memory amounts);
+
+    function quote(
+        uint256 amountA,
+        uint256 reserveA,
+        uint256 reserveB
+    ) external pure returns (uint256 amountB);
+
+    function removeLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    ) external returns (uint256 amountA, uint256 amountB);
+
+    function removeLiquidityETH(
+        address token,
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountETHMin,
+        address to,
+        uint256 deadline
+    ) external returns (uint256 amountToken, uint256 amountETH);
+
+    function removeLiquidityETHSupportingFeeOnTransferTokens(
+        address token,
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountETHMin,
+        address to,
+        uint256 deadline
+    ) external returns (uint256 amountETH);
+
+    function removeLiquidityETHWithPermit(
+        address token,
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountETHMin,
+        address to,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external returns (uint256 amountToken, uint256 amountETH);
+
+    function removeLiquidityETHWithPermitSupportingFeeOnTransferTokens(
+        address token,
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountETHMin,
+        address to,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external returns (uint256 amountETH);
+
+    function removeLiquidityWithPermit(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external returns (uint256 amountA, uint256 amountB);
+
+    function swapETHForExactTokens(
+        uint256 amountOut,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external payable returns (uint256[] memory amounts);
+
+    function swapExactETHForTokens(
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external payable returns (uint256[] memory amounts);
+
+    function swapExactETHForTokensSupportingFeeOnTransferTokens(
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external payable;
+
+    function swapExactTokensForETH(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function swapExactTokensForETHSupportingFeeOnTransferTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external;
+
+    function swapExactTokensForTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external;
+
+    function swapTokensForExactETH(
+        uint256 amountOut,
+        uint256 amountInMax,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function swapTokensForExactTokens(
+        uint256 amountOut,
+        uint256 amountInMax,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    receive() external payable;
+}

--- a/tests/uniswap_withdraw_module/conftest.py
+++ b/tests/uniswap_withdraw_module/conftest.py
@@ -1,0 +1,30 @@
+import pytest
+from brownie import UniswapWithdrawModule, interface
+
+
+@pytest.fixture(scope="session")
+def ulp():
+    # UNI/WETH
+    # https://goerli.etherscan.io/address/0x28cee28a7C4b4022AC92685C07d2f33Ab1A0e122
+    return interface.IUniswapV2Pair("0x28cee28a7C4b4022AC92685C07d2f33Ab1A0e122")
+
+
+@pytest.fixture(scope="session")
+def uni_v2_router():
+    return interface.IUniswapV2Router02("0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D")
+
+
+@pytest.fixture()
+def ulp_whale(accounts):
+    # https://goerli.etherscan.io/token/0x28cee28a7c4b4022ac92685c07d2f33ab1a0e122#balances
+    return accounts.at("0x41653c7d61609D856f29355E404F310Ec4142Cfb", force=True)
+
+
+@pytest.fixture()
+def module(safe, deployer):
+    module = UniswapWithdrawModule.deploy(safe, {"from": deployer})
+    safe.enableModule(module.address, {"from": safe})
+    address_one = "0x0000000000000000000000000000000000000001"
+    assert module.address in safe.getModulesPaginated(address_one, 10)[0]
+
+    return module

--- a/tests/uniswap_withdraw_module/test_withdraw.py
+++ b/tests/uniswap_withdraw_module/test_withdraw.py
@@ -1,4 +1,4 @@
-from brownie import reverts
+from brownie import accounts, reverts
 
 
 def test_withdraw_uniswap_v2(safe, module, ulp, ulp_whale, deployer):
@@ -23,3 +23,8 @@ def test_withdraw_uniswap_v2_no_balance(safe, module, ulp, deployer):
 
     with reverts():
         module.uniswapV2Withdraw(ulp.address, {"from": deployer})
+
+
+def test_withdraw_uniswap_v2_false_ulp(module, deployer):
+    with reverts():
+        module.uniswapV2Withdraw(accounts[5], {"from": deployer})

--- a/tests/uniswap_withdraw_module/test_withdraw.py
+++ b/tests/uniswap_withdraw_module/test_withdraw.py
@@ -1,4 +1,4 @@
-from brownie import accounts
+from brownie import reverts
 
 
 def test_withdraw_uniswap_v2(safe, module, ulp, ulp_whale, deployer):
@@ -8,7 +8,7 @@ def test_withdraw_uniswap_v2(safe, module, ulp, ulp_whale, deployer):
     assert ulp_balance >= token_amount
     assert ulp_balance > 0
 
-    ether_bal_before = accounts.at(safe, force=True).balance()
+    # ether_bal_before = accounts.at(safe, force=True).balance()
 
     module.uniswapV2Withdraw(ulp.address, {"from": deployer})
 
@@ -16,3 +16,10 @@ def test_withdraw_uniswap_v2(safe, module, ulp, ulp_whale, deployer):
 
     # uncomment once weth withdrawal is implemented
     # assert accounts.at(safe, force=True).balance() > ether_bal_before
+
+
+def test_withdraw_uniswap_v2_no_balance(safe, module, ulp, deployer):
+    assert ulp.balanceOf(safe) == 0
+
+    with reverts():
+        module.uniswapV2Withdraw(ulp.address, {"from": deployer})

--- a/tests/uniswap_withdraw_module/test_withdraw.py
+++ b/tests/uniswap_withdraw_module/test_withdraw.py
@@ -1,0 +1,18 @@
+from brownie import accounts
+
+
+def test_withdraw_uniswap_v2(safe, module, ulp, ulp_whale, deployer):
+    token_amount = 100e18
+    ulp.transfer(safe, token_amount, {"from": ulp_whale})
+    ulp_balance = ulp.balanceOf(safe)
+    assert ulp_balance >= token_amount
+    assert ulp_balance > 0
+
+    ether_bal_before = accounts.at(safe, force=True).balance()
+
+    module.uniswapV2Withdraw(ulp.address, {"from": deployer})
+
+    assert ulp.balanceOf(safe) == 0
+
+    # uncomment once weth withdrawal is implemented
+    # assert accounts.at(safe, force=True).balance() > ether_bal_before


### PR DESCRIPTION
tried deploying but brownie is being brownie:
```
Transaction sent: 0xecf13e6fa3b007a1398c56408105638a5eb791208ae13238e3e02af9b3c9d5a3
  Gas price: 0.0 gwei   Gas limit: 20000000   Nonce: 0
  UniswapWithdrawModule.constructor confirmed   Block: 8834175   Gas used: 699930 (3.50%)
  UniswapWithdrawModule deployed at: 0xfd7ba14DBDd791D6319147A87AE042C80F2B057a

  File "brownie/_cli/run.py", line 51, in main
    return_value, frame = run(
  File "brownie/project/scripts.py", line 110, in run
    return_value = f_locals[method_name](*args, **kwargs)
  File "./scripts/deploy_module_factory.py", line 7, in main
    return UniswapWithdrawModule.deploy(safe, {"from": deployer}, publish_source=True)
  File "brownie/network/contract.py", line 549, in __call__
    return tx["from"].deploy(
  File "brownie/network/account.py", line 557, in deploy
    contract.publish_source(deployed_contract, silent=silent)
  File "brownie/network/contract.py", line 359, in publish_source
    contract_info = self.get_verification_info()
  File "brownie/network/contract.py", line 316, in get_verification_info
    self._flattener = Flattener(source_fp, self._name, remaps, compiler_settings)
  File "brownie/project/flattener.py", line 30, in __init__
    self.traverse(primary_source_fp)
  File "brownie/project/flattener.py", line 71, in traverse
    self.traverse(import_path)
  File "brownie/project/flattener.py", line 50, in traverse
    source = fp_obj.read_text()
  File "/Users/gosuto/.pyenv/versions/3.9.16/lib/python3.9/pathlib.py", line 1266, in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
  File "/Users/gosuto/.pyenv/versions/3.9.16/lib/python3.9/pathlib.py", line 1252, in open
    return io.open(self, mode, buffering, encoding, errors, newline,
  File "/Users/gosuto/.pyenv/versions/3.9.16/lib/python3.9/pathlib.py", line 1120, in _opener
    return self._accessor.open(self, flags, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/Users/gosuto/Documents/safe_panic_modules/contracts/modules/interfaces/ISafe.sol'
Terminating local RPC client...
```